### PR TITLE
[ULIB-12] 잘못된 모듈 확장자와 경로 수정

### DIFF
--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -4,13 +4,13 @@
 	"version": "1.0.0",
 	"type": "module",
 	"packageManager": "pnpm@8.4.0",
-	"main": "dist/@uoslife/design-system.umd.cjs",
+	"main": "dist/@uoslife/design-system.umd.js",
 	"module": "dist/@uoslife/design-system.js",
 	"types": "dist/index.d.ts",
 	"exports": {
 		".": {
 			"import": "./dist/@uoslife/design-system.es.js",
-			"require": "./dist/@uoslife/design-system.umd.cjs"
+			"require": "./dist/@uoslife/design-system.umd.js"
 		}
 	},
 	"files": [
@@ -25,12 +25,12 @@
 		"exports": {
 			".": {
 				"import": "./dist/@uoslife/design-system.es.js",
-				"require": "./dist/@uoslife/design-system.umd.cjs",
+				"require": "./dist/@uoslife/design-system.umd.js",
 				"types": "./dist/index.d.ts"
 			},
 			"./package.json": "./package.json"
 		},
-		"main": "dist/@uoslife/design-system.umd.cjs",
+		"main": "dist/@uoslife/design-system.umd.js",
 		"module": "dist/@uoslife/design-system.js",
 		"types": "dist/index.d.ts",
 		"@uoslife:registry": "https://npm.pkg.github.com",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -4,13 +4,13 @@
 	"version": "0.3.2",
 	"type": "module",
 	"packageManager": "pnpm@8.4.0",
-	"main": "dist/@uoslife/react.umd.cjs",
+	"main": "dist/@uoslife/react.umd.js",
 	"module": "dist/@uoslife/react.js",
 	"types": "dist/index.d.ts",
 	"exports": {
 		".": {
 			"import": "./dist/@uoslife/react.es.js",
-			"require": "./dist/@uoslife/react.umd.cjs",
+			"require": "./dist/@uoslife/react.umd.js",
 			"types": "./dist/index.d.ts"
 		}
 	},
@@ -32,11 +32,11 @@
 		"exports": {
 			".": {
 				"import": "./dist/@uoslife/react.es.js",
-				"require": "./dist/@uoslife/react.umd.cjs",
+				"require": "./dist/@uoslife/react.umd.js",
 				"types": "./dist/index.d.ts"
 			}
 		},
-		"main": "dist/@uoslife/react.umd.cjs",
+		"main": "dist/@uoslife/react.umd.js",
 		"module": "dist/@uoslife/react.js",
 		"types": "dist/index.d.ts",
 		"@uoslife:registry": "https://npm.pkg.github.com",


### PR DESCRIPTION
- 빌드시 main 모듈의 확장자가 .js인데 .cjs로 선언되어 있어 수정합니다.