### PR TITLE
[ULIB-17] storybook 실행되도록 수정

### DIFF
--- a/packages/design-system/.storybook/main.ts
+++ b/packages/design-system/.storybook/main.ts
@@ -18,6 +18,11 @@ const config: StorybookConfig = {
 	},
 	viteFinal: async (config) => {
 		config.resolve!.alias!["@"] = path.resolve(__dirname, "../src/");
+		config.resolve!.alias!["@uoslife/react"] = path.resolve(
+			__dirname,
+			"../node_modules/@uoslife/react/@uoslife/react.es.js"
+		);
+		config.resolve!.alias!["react-native"] = "react-native-web";
 		return config;
 	},
 };


### PR DESCRIPTION
- storybook 실행 되도록 config파일을 수정했습니다.
1. react-native-web으로 컴파일 되도록 변경
2. @uoslife/react 패키지 읽지 못하는 문제(설치된 node_modules의 패키지에 package.json이 없기 때문에)를 직접 모듈을 가져오도록 alias를 변경