### PR TITLE
[ULIB-33] timer 훅 분리 및 수정

### DIFF
--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@uoslife/design-system",
 	"private": false,
-	"version": "1.0.43",
+	"version": "1.0.44",
 	"type": "module",
 	"packageManager": "pnpm@8.4.0",
 	"main": "dist/@uoslife/design-system.es.js",

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@uoslife/design-system",
 	"private": false,
-	"version": "1.0.44",
+	"version": "1.0.45",
 	"type": "module",
 	"packageManager": "pnpm@8.4.0",
 	"main": "dist/@uoslife/design-system.es.js",
@@ -48,7 +48,7 @@
 	"dependencies": {
 		"@emotion/native": "^11.11.0",
 		"@emotion/react": "^11.11.1",
-		"@uoslife/react": "^1.0.3",
+		"@uoslife/react": "^1.0.4",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
 		"react-native": "^0.72.2",

--- a/packages/design-system/src/lib/common/atom/input/Input.stories.tsx
+++ b/packages/design-system/src/lib/common/atom/input/Input.stories.tsx
@@ -21,6 +21,7 @@ export const Secondary = {
 		<Input
 			children={
 				<Timer
+					currentTime="00:00"
 					style={css`
 						position: absolute;
 						top: 20px;

--- a/packages/design-system/src/lib/common/atom/timer/Timer.tsx
+++ b/packages/design-system/src/lib/common/atom/timer/Timer.tsx
@@ -1,20 +1,13 @@
 import { Txt, TxtProps } from "../.";
 
-import { useTimer } from "@uoslife/react";
+type Props = {
+	currentTime: string;
+} & Omit<TxtProps, "label" | "color" | "typograph">;
 
-type Props = Omit<TxtProps, "label" | "color" | "typograph">;
-
-const VERIFICATION_TIMER_MIN = 3;
-const VERIFICATION_TIMER_SEC = 0;
-
-export const Timer = ({ ...props }: Props) => {
-	const { currentTime, isFinish } = useTimer(
-		VERIFICATION_TIMER_MIN,
-		VERIFICATION_TIMER_SEC
-	);
+export const Timer = ({ currentTime, ...props }: Props) => {
 	return (
 		<Txt
-			label={isFinish ? "done" : currentTime}
+			label={currentTime}
 			color={"grey10"}
 			typograph={"titleLarge"}
 			{...props}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@uoslife/react",
 	"private": false,
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"type": "module",
 	"packageManager": "pnpm@8.4.0",
 	"main": "dist/@uoslife/react.es.js",

--- a/packages/react/src/lib/hooks/useTimer.tsx
+++ b/packages/react/src/lib/hooks/useTimer.tsx
@@ -1,16 +1,37 @@
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
-export const useTimer = (initMin: number, initSec: number) => {
+type useTimerProps = {
+	initMin: number;
+	initSec: number;
+	autoStart?: boolean;
+};
+
+const addZero = (num: number) => {
+	if (num < 10) return "0" + num.toString();
+	else return num.toString();
+};
+
+export const useTimer = ({
+	initMin,
+	initSec,
+	autoStart = true,
+}: useTimerProps) => {
 	const [min, setMin] = useState(initMin);
 	const [sec, setSec] = useState(initSec);
+	const [isStart, setIsStart] = useState(autoStart);
 	const [isFinish, setIsFinish] = useState(false);
 
-	const addZero = useCallback((num: number) => {
-		if (num < 10) return "0" + num.toString();
-		else return num.toString();
-	}, []);
+	const startTimer = () => {
+		setIsStart(true);
+	};
+
+	const resetTimer = () => {
+		setMin(initMin);
+		setSec(initSec);
+	};
 
 	useEffect(() => {
+		if (!isStart) return;
 		const countDown = setInterval(() => {
 			if (sec === 0 && min === 0) {
 				setIsFinish(true);
@@ -26,5 +47,5 @@ export const useTimer = (initMin: number, initSec: number) => {
 		return () => clearInterval(countDown);
 	});
 	const currentTime = addZero(min) + ":" + addZero(sec);
-	return { currentTime, isFinish };
+	return { currentTime, isFinish, startTimer, resetTimer };
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ importers:
         specifier: ^11.11.1
         version: 11.11.1(@types/react@18.2.17)(react@18.2.0)
       '@uoslife/react':
-        specifier: ^1.0.3
+        specifier: ^1.0.4
         version: link:../react/dist
       react:
         specifier: ^18.2.0


### PR DESCRIPTION
# Summary
- Timer 컴포넌트에서 timer 상태를 외부에서 주입하는 방식으로 사용하기 위해 Timer 컴포넌트 내부의 useTimer훅을 제거하였습니다. 
- useTimer에 받는 인자를 object로 변경하였습니다.
- autoStart 옵션을 추가하였습니다. 기본으로 true를 받습니다.
- 0를 추가하여 string으로 반환하는 addZero함수를 훅 외부로 분리하였습니다.