### PR TITLE
fix: 일부 컴포넌트에 style이 적용 안되는 이슈 - #38

### DIFF
--- a/packages/design-system/src/lib/common/atom/button/Button.tsx
+++ b/packages/design-system/src/lib/common/atom/button/Button.tsx
@@ -91,6 +91,7 @@ export const Button = ({
 	iconName,
 	iconColor = "white",
 	onPress,
+	style,
 	...props
 }: ButtonProps) => {
 	const [isPressed, setIsPressed] = useState(false);
@@ -111,15 +112,16 @@ export const Button = ({
 				}}
 				{...props}
 				isPressed={isPressed}
-				style={
+				style={[
 					isFullWidth
 						? css`
 								width: 100%;
 						  `
 						: css`
 								align-self: center;
-						  `
-				}
+						  `,
+					{ ...(style as object) },
+				]}
 			>
 				<S.ButtonInnerWrapper>
 					{!!iconName && (

--- a/packages/design-system/src/lib/common/atom/icon/Icon.tsx
+++ b/packages/design-system/src/lib/common/atom/icon/Icon.tsx
@@ -14,11 +14,20 @@ const getImageUrl = (name: string) => {
 		.href;
 };
 
-export const Icon = ({ name, width, height, color, ...props }: IconProps) => {
+export const Icon = ({
+	name,
+	width,
+	height,
+	color,
+	style,
+	...props
+}: IconProps) => {
 	return (
 		<Image
 			source={{ uri: getImageUrl(name) }}
-			style={{ width, height, tintColor: colors[color] }}
+			style={[
+				{ width, height, tintColor: colors[color], ...(style as object) },
+			]}
 			{...props}
 		/>
 	);

--- a/packages/design-system/src/lib/common/atom/txt/Txt.tsx
+++ b/packages/design-system/src/lib/common/atom/txt/Txt.tsx
@@ -10,13 +10,16 @@ export type TxtProps = {
 	typograph: typographsType;
 } & TextProps;
 
-export const Txt = ({ label, color, typograph, ...props }: TxtProps) => {
+export const Txt = ({ label, color, typograph, style, ...props }: TxtProps) => {
 	return (
 		<Text
-			style={css`
-				color: ${colors[color]};
-				${typographs[typograph]}
-			`}
+			style={[
+				css`
+					color: ${colors[color]};
+					${typographs[typograph]}
+				`,
+				{ ...(style as object) },
+			]}
 			{...props}
 		>
 			{label}


### PR DESCRIPTION
#Summary
- 일부 컴포넌트에 style 속성을 할당하였을 때 style 이 덮어써지는 문제가 있었습니다.
참고: https://github.com/uoslife/rebuild-client/pull/103
- 이에 확장된 props의 style속성을 컴포넌트 내부의 style props에 명시적으로 할당하였습니다. 