### PR TITLE
Button 컴포넌트 수정

### DIFF
--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@uoslife/design-system",
 	"private": false,
-	"version": "1.0.56",
+	"version": "1.0.57",
 	"type": "module",
 	"packageManager": "pnpm@8.4.0",
 	"main": "dist/@uoslife/design-system.es.js",

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@uoslife/design-system",
 	"private": false,
-	"version": "1.0.55",
+	"version": "1.0.56",
 	"type": "module",
 	"packageManager": "pnpm@8.4.0",
 	"main": "dist/@uoslife/design-system.es.js",

--- a/packages/design-system/src/lib/common/atom/button/Button.stories.tsx
+++ b/packages/design-system/src/lib/common/atom/button/Button.stories.tsx
@@ -28,6 +28,5 @@ export const WithIcon: Story = {
 		isRounded: false,
 		isFullWidth: false,
 		iconName: "openInNew",
-		iconColor: "primaryBrand",
 	},
 };

--- a/packages/design-system/src/lib/common/atom/button/Button.tsx
+++ b/packages/design-system/src/lib/common/atom/button/Button.tsx
@@ -68,7 +68,7 @@ const sizeToTypograph = (size: ButtonProps["size"]) => {
 
 export const Button = ({
 	label,
-	size = "medium",
+	size = "large",
 	variant = "filled",
 	isEnabled = true,
 	isRounded = false,

--- a/packages/design-system/src/lib/common/atom/button/Button.tsx
+++ b/packages/design-system/src/lib/common/atom/button/Button.tsx
@@ -21,38 +21,24 @@ const buttonStateToColor = (
 ) => {
 	/** disabled */
 	if (!isEnabled) return colors.grey40;
-	/** enabled */
+
+	/** pressed */
 	if (isPressed) return colors.primaryUi;
-	else return colors.primaryBrand;
+	/** enabled */
+	if (isEnabled) return colors.primaryBrand;
 };
 
-const variantToStyle = (
+const buttonStateToUnderlayColor = (
 	variant: ButtonProps["variant"],
-	isEnabled: ButtonProps["isEnabled"],
-	isPressed: boolean
+	isEnabled: ButtonProps["isEnabled"]
 ) => {
-	switch (variant) {
-		case "filled":
-			return css`
-				color: ${colors.white};
-				background-color: ${buttonStateToColor(isEnabled, isPressed)};
-			`;
-		case "outline":
-			return css`
-				color: ${buttonStateToColor(isEnabled, isPressed)};
-				border: 1px solid ${buttonStateToColor(isEnabled, isPressed)};
-				background-color: ${isEnabled && isPressed
-					? colors.primaryLighterAlt
-					: ""};
-			`;
-		case "text":
-			return css`
-				color: ${buttonStateToColor(isEnabled, isPressed)};
-				background-color: ${isEnabled && isPressed
-					? colors.primaryLighterAlt
-					: ""};
-			`;
+	if (!isEnabled) {
+		if (variant !== "filled") return colors.white;
+		return colors.grey40;
 	}
+	if (variant === "filled") return colors.primaryUi;
+
+	return colors.primaryLighterAlt;
 };
 
 const sizeToPadding = (size: ButtonProps["size"]) => {
@@ -95,6 +81,7 @@ export const Button = ({
 	...props
 }: ButtonProps) => {
 	const [isPressed, setIsPressed] = useState(false);
+
 	return (
 		<View>
 			<S.ButtonWrapper
@@ -122,6 +109,7 @@ export const Button = ({
 						  `,
 					{ ...(style as object) },
 				]}
+				underlayColor={buttonStateToUnderlayColor(variant, isEnabled)}
 			>
 				<S.ButtonInnerWrapper>
 					{!!iconName && (
@@ -152,8 +140,17 @@ const S = {
 	>`
 		padding: ${({ size }) => sizeToPadding(size)};
 		border-radius: ${({ isRounded }) => (!isRounded ? "12px" : "100px")};
-		${({ variant, isEnabled, isPressed }) =>
-			variantToStyle(variant, isEnabled, isPressed)}
+
+		${({ variant, isEnabled, isPressed }) => [
+			variant === "outline" &&
+				css`
+					border: 1px solid ${buttonStateToColor(isEnabled, isPressed)};
+				`,
+			variant === "filled" &&
+				css`
+					background-color: ${buttonStateToColor(isEnabled, isPressed)};
+				`,
+		]};
 	`,
 	ButtonInnerWrapper: styled.View`
 		display: flex;

--- a/packages/design-system/src/lib/common/atom/button/Button.tsx
+++ b/packages/design-system/src/lib/common/atom/button/Button.tsx
@@ -109,7 +109,7 @@ export const Button = ({
 				]}
 				underlayColor={buttonStateToUnderlayColor(variant, isEnabled)}
 			>
-				<S.ButtonInnerWrapper>
+				<S.ButtonInnerWrapper size={size}>
 					{!!iconName && (
 						<Icon
 							name={iconName}
@@ -159,12 +159,12 @@ const S = {
 				`,
 		]};
 	`,
-	ButtonInnerWrapper: styled.View`
+	ButtonInnerWrapper: styled.View<Pick<ButtonProps, "size">>`
 		display: flex;
 		flex-direction: row;
 		align-items: center;
 		justify-content: center;
-		gap: 2px;
+		gap: ${({ size }) => (size === "small" ? "2px" : "4px")};
 	`,
 	ButtonText: styled.Text<
 		Pick<ButtonProps, "variant" | "isEnabled"> & { isPressed: boolean }

--- a/packages/design-system/src/lib/common/atom/button/Button.tsx
+++ b/packages/design-system/src/lib/common/atom/button/Button.tsx
@@ -11,7 +11,6 @@ export type ButtonProps = {
 	isRounded?: boolean;
 	isFullWidth?: boolean;
 	iconName?: IconsNameType;
-	iconColor?: colorsType;
 	onPress?: () => void;
 } & Omit<TouchableHighlightProps, "onPress">;
 
@@ -25,7 +24,7 @@ const buttonStateToColor = (
 	/** pressed */
 	if (isPressed) return colors.primaryUi;
 	/** enabled */
-	if (isEnabled) return colors.primaryBrand;
+	return colors.primaryBrand;
 };
 
 const buttonStateToUnderlayColor = (
@@ -75,7 +74,6 @@ export const Button = ({
 	isRounded = false,
 	isFullWidth = false,
 	iconName,
-	iconColor = "white",
 	onPress,
 	style,
 	...props
@@ -113,7 +111,16 @@ export const Button = ({
 			>
 				<S.ButtonInnerWrapper>
 					{!!iconName && (
-						<Icon name={iconName} width={24} height={24} color={iconColor} />
+						<Icon
+							name={iconName}
+							width={24}
+							height={24}
+							color_rgb={
+								variant === "filled"
+									? (colors.white as colorsType)
+									: (buttonStateToColor(isEnabled, isPressed) as colorsType)
+							}
+						/>
 					)}
 					<S.ButtonText
 						variant={variant}

--- a/packages/design-system/src/lib/common/atom/icon/Icon.tsx
+++ b/packages/design-system/src/lib/common/atom/icon/Icon.tsx
@@ -6,7 +6,8 @@ export type IconProps = {
 	name: IconsNameType;
 	width: number;
 	height: number;
-	color: colorsType;
+	color?: colorsType;
+	color_rgb?: string;
 } & Omit<ImageProps, "source">;
 
 const getImageUrl = (name: string) => {
@@ -19,6 +20,7 @@ export const Icon = ({
 	width,
 	height,
 	color,
+	color_rgb,
 	style,
 	...props
 }: IconProps) => {
@@ -26,7 +28,12 @@ export const Icon = ({
 		<Image
 			source={{ uri: getImageUrl(name) }}
 			style={[
-				{ width, height, tintColor: colors[color], ...(style as object) },
+				{
+					width,
+					height,
+					tintColor: (color && colors[color]) ?? color_rgb,
+					...(style as object),
+				},
 			]}
 			{...props}
 		/>

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@uoslife/react",
 	"private": false,
-	"version": "1.0.12",
+	"version": "1.0.13",
 	"type": "module",
 	"packageManager": "pnpm@8.4.0",
 	"main": "dist/@uoslife/react.es.js",


### PR DESCRIPTION
# Summary

- 버튼 클릭 시(pressed 상태) 검은 배경이 나오는 문제를 해결하였습니다.
- buttonStateToUnderlayColor 함수를 선언하여 아래의 pressed상태의 case에 맞게 배경 색상을 할당하였습니다.
<img width="305" alt="스크린샷 2023-10-07 오후 8 04 50" src="https://github.com/uoslife/uoslife-library/assets/76601773/d7546320-b7ab-4d16-b55c-6bb6f77be28e">

- 버튼 size prop에 따라 icon과 label 사이의 간격이 달라지도록 수정하였습니다. 해당 간격은 아래와 같습니다.
    - small: 2px
    - 나머지: 4px
- 버튼 내부의 icon도 버튼 상태에 따라 색상이 같이 변동되도록 수정하였습니다.
이에따라 ButtonProps 에서 iconColor prop을 삭제하였습니다.

- size prop의 default를 'medium'에서 'large'로 변경하였습니다.
