### PR TITLE
웹뷰 bridge 및 driver 구현

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -73,5 +73,5 @@
 			}
 		}
 	},
-	"gitHead": "8153a9436be5ea5eb34407c74a0b343720ff17fc"
+	"gitHead": "350e15477991532ca7d7f4ab0597cf8d5d381a2a"
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@uoslife/react",
 	"private": false,
-	"version": "1.1.5",
+	"version": "1.1.6",
 	"type": "module",
 	"packageManager": "pnpm@8.4.0",
 	"main": "dist/@uoslife/react.es.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@uoslife/react",
 	"private": false,
-	"version": "1.1.4",
+	"version": "1.1.5",
 	"type": "module",
 	"packageManager": "pnpm@8.4.0",
 	"main": "dist/@uoslife/react.es.js",

--- a/packages/webview/package.json
+++ b/packages/webview/package.json
@@ -24,6 +24,7 @@
 		"react-native-web": "^0.19.7",
 		"react-native-webview": "^13.6.4",
 		"typescript": "^5.2.2",
+		"uuid-random": "^1.3.2",
 		"vite": "^5.0.8",
 		"vite-plugin-dts": "^3.3.1"
 	}

--- a/packages/webview/package.json
+++ b/packages/webview/package.json
@@ -27,5 +27,18 @@
 		"uuid-random": "^1.3.2",
 		"vite": "^5.0.8",
 		"vite-plugin-dts": "^3.3.1"
+	},
+	"lerna": {
+		"command": {
+			"publish": {
+				"assets": [
+					"package.json",
+					{
+						"from": "dist/*",
+						"to": "dist"
+					}
+				]
+			}
+		}
 	}
 }

--- a/packages/webview/package.json
+++ b/packages/webview/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@uoslife/webview",
 	"private": true,
-	"version": "0.0.0",
+	"version": "0.0.1",
 	"type": "module",
 	"scripts": {
 		"dev": "vite",

--- a/packages/webview/src/bridges/bridge.ts
+++ b/packages/webview/src/bridges/bridge.ts
@@ -1,0 +1,9 @@
+import { Driver } from '../driver';
+
+export class Bridge {
+  constructor(private readonly _driver: Driver) {}
+
+  get driver() {
+    return this._driver;
+  }
+}

--- a/packages/webview/src/bridges/index.ts
+++ b/packages/webview/src/bridges/index.ts
@@ -1,0 +1,1 @@
+export { makeUoslifeBridge } from './uoslife.bridge';

--- a/packages/webview/src/bridges/uoslife.bridge.ts
+++ b/packages/webview/src/bridges/uoslife.bridge.ts
@@ -1,0 +1,28 @@
+import { Driver } from '../driver';
+import {
+  AccessTokenType,
+  PROTOCOL_NAME,
+  UserInfoType,
+} from '../protocols/types';
+import { Bridge } from './bridge';
+
+type MakeUoslifeBridgeType = { driver: Driver };
+
+export class UoslifeBridge extends Bridge {
+  constructor(_driver: Driver) {
+    super(_driver);
+  }
+
+  getAccessToken() {
+    return super.driver.request<AccessTokenType>(
+      PROTOCOL_NAME.USER_ACCESS_TOKEN,
+    );
+  }
+  getUserInfo() {
+    return super.driver.request<UserInfoType>(PROTOCOL_NAME.USER_USER_INFO);
+  }
+}
+
+export const makeUoslifeBridge = ({ driver }: MakeUoslifeBridgeType) => {
+  return new UoslifeBridge(driver);
+};

--- a/packages/webview/src/client/hooks.ts
+++ b/packages/webview/src/client/hooks.ts
@@ -1,0 +1,28 @@
+import WebView from "react-native-webview";
+import { useEffect, useRef } from "react";
+import { BackHandler, Platform } from "react-native";
+
+const useWebview = () => {
+	const webViewRef = useRef<WebView>();
+	const onAndroidBackPress = () => {
+		if (webViewRef.current) {
+			webViewRef.current.goBack();
+			return true; // prevent default behavior (exit app)
+		}
+		return false;
+	};
+
+	useEffect(() => {
+		if (Platform.OS === "android") {
+			BackHandler.addEventListener("hardwareBackPress", onAndroidBackPress);
+			return () => {
+				BackHandler.removeEventListener(
+					"hardwareBackPress",
+					onAndroidBackPress
+				);
+			};
+		}
+	}, []);
+};
+
+export default useWebview;

--- a/packages/webview/src/client/index.ts
+++ b/packages/webview/src/client/index.ts
@@ -1,0 +1,28 @@
+import WebView, { WebViewMessageEvent } from "react-native-webview";
+import { Protocol } from "../protocols";
+import { ProtocolPayloadType } from "../protocols/types";
+
+type OnMessageFromWebViewProps = WebViewMessageEvent &
+	ProtocolPayloadType & {
+		webviewRef: React.MutableRefObject<WebView<object> | null>;
+	};
+
+export const onMessageFromWebView = ({
+	nativeEvent,
+	webviewRef,
+	userPayload,
+	accessTokenPayload,
+}: OnMessageFromWebViewProps) => {
+	const protocol = new Protocol(JSON.parse(nativeEvent.data));
+	switch (protocol.name) {
+		case "user.accessToken":
+			webviewRef.current?.postMessage(
+				JSON.stringify({ ...protocol, payload: { ...accessTokenPayload } })
+			);
+			return;
+		case "user.userInfo":
+			webviewRef.current?.postMessage(
+				JSON.stringify({ ...protocol, payload: { ...userPayload } })
+			);
+	}
+};

--- a/packages/webview/src/driver/index.ts
+++ b/packages/webview/src/driver/index.ts
@@ -1,0 +1,66 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Protocol, RequestProps } from '../protocols';
+import { ProtocolNamesType } from '../protocols/types';
+import { IDriver } from './types';
+
+export class Driver implements IDriver {
+  private _isInstalled: boolean = false;
+  private readonly requests: Map<string, RequestProps<any, any>> = new Map();
+
+  install() {
+    if (this.isInstalled) {
+      console.log('이미 드라이버가 설치되어 있습니다.');
+      return this;
+    }
+    // if (window.environment === 'web') {
+    //   console.log('웹 환경에서는 드라이버를 사용할 수 없습니다.');
+    //   return;
+    // }
+    window.addEventListener('message', e => this.onMessage(e));
+    this.isInstalled = true;
+    return this;
+  }
+
+  unInstall() {
+    window.removeEventListener('message', e => this.onMessage(e));
+    this.isInstalled = false;
+  }
+
+  request<U>(name: ProtocolNamesType): Promise<U> {
+    const protocol = new Protocol<U>({ name });
+
+    //@ts-expect-error: window has ReactNativeWebview
+    window.ReactNativeWebView.postMessage(protocol.toMessage());
+
+    return new Promise((resolve, reject) => {
+      this.requests.set(protocol.id, { protocol, resolve, reject });
+    });
+  }
+
+  private onMessage(message: MessageEvent): void {
+    const protocol = new Protocol(JSON.parse(message.data));
+    const request = this.requests.get(protocol.id);
+
+    if (!request) {
+      console.log('요청이 존재하지 않습니다.');
+    } else {
+      request.resolve(protocol.payload);
+      this.requests.delete(protocol.id);
+    }
+  }
+
+  get isInstalled() {
+    return this._isInstalled;
+  }
+  set isInstalled(val: boolean) {
+    this._isInstalled = val;
+  }
+}
+
+export const installUoslifeDriver = () => {
+  return { driver: new Driver().install() };
+};
+
+export const unInstallUoslifeDriver = () => {
+  return { driver: new Driver().unInstall() };
+};

--- a/packages/webview/src/driver/types.ts
+++ b/packages/webview/src/driver/types.ts
@@ -1,0 +1,23 @@
+import { Driver } from '.';
+
+export interface IDriver {
+  /**
+   * 드라이버가 설치되어 있는지 확인합니다.
+   */
+  isInstalled: boolean;
+
+  /**
+   * 드라이버를 설치합니다.
+   */
+  install(): Driver | undefined;
+
+  /**
+   * 드라이버를 제거합니다.
+   */
+  unInstall(): void;
+
+  /**
+   * native client에 요청을 보냅니다.
+   */
+  request<U, D>(name: string, payload: U): Promise<D>;
+}

--- a/packages/webview/src/index.ts
+++ b/packages/webview/src/index.ts
@@ -1,0 +1,4 @@
+export * from "./bridges";
+export * from "./driver";
+export * from "./protocols";
+export * from "./client";

--- a/packages/webview/src/protocols/index.ts
+++ b/packages/webview/src/protocols/index.ts
@@ -1,0 +1,30 @@
+import uuid from "uuid-random";
+import { ProtocolNamesType } from "./types";
+
+export type RequestProps<U, D> = {
+	protocol: Protocol<U>;
+	resolve: (value: D) => void;
+	reject: (reason: string) => void;
+};
+
+export type ProtocolProps<T> = {
+	id?: string;
+	name: ProtocolNamesType;
+	payload?: T;
+};
+
+export class Protocol<T> {
+	id: string;
+	name: ProtocolNamesType;
+	payload: T | object;
+
+	constructor(data: ProtocolProps<T>) {
+		this.id = data.id ?? uuid();
+		this.name = data.name;
+		this.payload = data.payload ?? {};
+	}
+
+	toMessage(): string {
+		return JSON.stringify(this);
+	}
+}

--- a/packages/webview/src/protocols/types.ts
+++ b/packages/webview/src/protocols/types.ts
@@ -1,0 +1,32 @@
+// enum 사용시 빌드 단계에서 에러 발생
+export const PROTOCOL_NAME = {
+  USER_ACCESS_TOKEN: 'user.accessToken' as const,
+  USER_USER_INFO: 'user.userInfo' as const,
+};
+
+export type ProtocolNamesType =
+  (typeof PROTOCOL_NAME)[keyof typeof PROTOCOL_NAME];
+
+export type UserInfoType = {
+  id: number;
+  name: string;
+  nickname: string;
+  birthday: string;
+  phone: string;
+  avatarUrl: string;
+  isVerified: boolean;
+  degree: string;
+  enrollmentStatus: string;
+  studentId: string;
+  departmentName: string;
+  collegeName: string;
+};
+
+export type AccessTokenType = {
+  accessToken?: string;
+};
+
+export type ProtocolPayloadType = {
+  userPayload: UserInfoType | null;
+  accessTokenPayload: AccessTokenType;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -200,6 +200,9 @@ importers:
       typescript:
         specifier: ^5.2.2
         version: 5.2.2
+      uuid-random:
+        specifier: ^1.3.2
+        version: 1.3.2
       vite:
         specifier: ^5.0.8
         version: 5.0.8
@@ -632,6 +635,7 @@ packages:
   /@babel/plugin-proposal-unicode-property-regex@7.18.6(@babel/core@7.22.9):
     resolution: {integrity: sha512-2BShG/d5yoZyXZfVePH91urL5wTG6ASZU9M4o03lKK8u8UW1y08OMttBSOADTcJrnPMpvDXRG3G8fyLh4ovs8w==}
     engines: {node: '>=4'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-unicode-property-regex instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
@@ -13690,6 +13694,10 @@ packages:
   /utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
+    dev: true
+
+  /uuid-random@1.3.2:
+    resolution: {integrity: sha512-UOzej0Le/UgkbWEO8flm+0y+G+ljUon1QWTEZOq1rnMAsxo2+SckbiZdKzAHHlVh6gJqI1TjC/xwgR50MuCrBQ==}
     dev: true
 
   /uuid@9.0.0:


### PR DESCRIPTION
# Key Changes

- webview와의 통신을 위한 bridge와 driver를 구현했습니다.

# Details

- driver는 client 앱과 webview와의 통신을 위한 환경설정 함수를 제공합니다. 메서드 타입은 아래와 같습니다.
```typescript
interface IDriver {
  /**
   * 드라이버가 설치되어 있는지 확인합니다.
   */
  isInstalled: boolean;

  /**
   * 드라이버를 설치합니다.
   */
  install(): Driver | undefined;

  /**
   * 드라이버를 제거합니다.
   */
  unInstall(): void;

  /**
   * native client에 요청을 보냅니다.
   */
  request<U, D>(name: string, payload: U): Promise<D>;
}
``` 
- bridge는 실제 통신을 담당합니다. 통신을 위해 비동기 Promise를 사용하며, 앱과 웹뷰 간 아래 Protocol을 주고받습니다.
```typescript
class Protocol<T> {
  id: string;
  name: ProtocolNamesType;
  payload: T | Object;

  // ...
}
``` 
- webview 프로젝트에서 사용방법은 아래와 같습니다.
```typescript
import { installUoslifeDriver, makeUoslifeBridge } from '@uoslife/webview';

const { driver } = installUoslifeDriver();
export const uoslifeBridge = makeUoslifeBridge({ driver });
``` 

# Closes Issue

close #54 
