### PR TITLE
[Design-system] dist 폴더구조 변경 및 web 컴포넌트 환경설정 

### DIFF
--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -4,35 +4,46 @@
 	"version": "1.1.2",
 	"type": "module",
 	"packageManager": "pnpm@8.4.0",
-	"main": "dist/@uoslife/design-system.es.js",
-	"module": "dist/@uoslife/design-system.umd.js",
-	"types": "dist/index.d.ts",
-	"exports": {
-		".": {
-			"import": "./dist/@uoslife/design-system.es.js",
-			"require": "./dist/@uoslife/design-system.umd.js"
-		}
-	},
 	"files": [
 		"dist/*"
 	],
+	"main": "dist/design-system.es.js",
+	"module": "dist/design-system.cjs.js",
+	"types": "dist/types/index.d.ts",
+	"exports": {
+		".": {
+			"import": "./dist/design-system.es.js",
+			"require": "./dist/design-system.cjs.js",
+			"types": "./dist/types/index.d.ts"
+		},
+		"./web": {
+			"import": "./dist/web/design-system.web.es.js",
+			"require": "./dist/web/design-system.web.cjs.js",
+			"types": "./dist/types/index.web.d.ts"
+		}
+	},
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/uoslife/uoslife-library.git",
 		"directory": "dist"
 	},
 	"publishConfig": {
+		"main": "dist/design-system.es.js",
+		"module": "dist/design-system.umd.js",
+		"types": "dist/types/index.d.ts",
 		"exports": {
 			".": {
-				"import": "./dist/@uoslife/design-system.es.js",
-				"require": "./dist/@uoslife/design-system.umd.js",
-				"types": "./dist/index.d.ts"
+				"import": "./dist/design-system.es.js",
+				"require": "./dist/design-system.cjs.js",
+				"types": "./dist/types/index.d.ts"
+			},
+			"./web": {
+				"import": "./dist/web/design-system.web.es.js",
+				"require": "./dist/web/design-system.web.cjs.js",
+				"types": "./dist/types/index.web.d.ts"
 			},
 			"./package.json": "./package.json"
 		},
-		"main": "dist/@uoslife/design-system.es.js",
-		"module": "dist/@uoslife/design-system.umd.js",
-		"types": "dist/index.d.ts",
 		"@uoslife:registry": "https://npm.pkg.github.com",
 		"directory": "dist"
 	},

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@uoslife/design-system",
 	"private": false,
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"type": "module",
 	"packageManager": "pnpm@8.4.0",
 	"files": [

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@uoslife/design-system",
 	"private": false,
-	"version": "1.1.2",
+	"version": "1.2.0",
 	"type": "module",
 	"packageManager": "pnpm@8.4.0",
 	"files": [

--- a/packages/design-system/src/lib/common/atom/index.web.ts
+++ b/packages/design-system/src/lib/common/atom/index.web.ts
@@ -1,0 +1,5 @@
+export * from "./txt/Txt.web";
+// export * from "./input/Input";
+// export * from "./timer/Timer";
+// export * from "./icon/Icon";
+// export * from "./button/Button";

--- a/packages/design-system/src/lib/common/atom/txt/Txt.web.tsx
+++ b/packages/design-system/src/lib/common/atom/txt/Txt.web.tsx
@@ -1,0 +1,28 @@
+import { Interpolation, Theme, css } from "@emotion/react";
+
+import { colors, typographs } from "../../../index.web";
+import { colorsType, typographsType } from "../../../.";
+
+export type TxtProps = {
+	label: string;
+	color: colorsType;
+	typograph: typographsType;
+	style?: Interpolation<Theme>;
+} & React.HTMLAttributes<HTMLParagraphElement>;
+
+export const Txt = ({ label, color, typograph, style, ...props }: TxtProps) => {
+	return (
+		<p
+			css={[
+				css`
+					color: ${colors[color]};
+					${typographs[typograph]}
+				`,
+				style,
+			]}
+			{...props}
+		>
+			{label}
+		</p>
+	);
+};

--- a/packages/design-system/src/lib/common/index.web.ts
+++ b/packages/design-system/src/lib/common/index.web.ts
@@ -1,0 +1,1 @@
+export * from "./atom/index.web";

--- a/packages/design-system/src/lib/constants/index.web.ts
+++ b/packages/design-system/src/lib/constants/index.web.ts
@@ -1,0 +1,3 @@
+export * from "./colors";
+export * from "./sizes";
+export * from "./typographs.web";

--- a/packages/design-system/src/lib/constants/typographs.web.ts
+++ b/packages/design-system/src/lib/constants/typographs.web.ts
@@ -1,0 +1,69 @@
+import { css } from "@emotion/react";
+
+export const typographs = {
+	headlineLarge: css`
+		font-size: 28px;
+		line-height: 36px;
+		font-family: "Pretendard-Bold";
+	`,
+	headlineMedium: css`
+		font-size: 24px;
+		line-height: 32px;
+		font-family: "Pretendard-Bold";
+	`,
+	headlineSmall: css`
+		font-size: 16px;
+		line-height: 24px;
+		font-family: "Pretendard-Light";
+	`,
+	titleLarge: css`
+		font-size: 20px;
+		line-height: 28px;
+		font-family: "Pretendard-SemiBold";
+	`,
+	titleMedium: css`
+		font-size: 18px;
+		line-height: 24px;
+		font-family: "Pretendard-SemiBold";
+	`,
+	titleSmall: css`
+		font-size: 16px;
+		line-height: 20px;
+		font-family: "Pretendard-Medium";
+	`,
+	bodyLarge: css`
+		font-size: 16px;
+		line-height: 24px;
+		font-family: "Pretendard-Regular";
+	`,
+	bodyMedium: css`
+		font-size: 14px;
+		line-height: 20px;
+		font-family: "Pretendard-Regular";
+	`,
+	bodySmall: css`
+		font-size: 12px;
+		line-height: 18px;
+		font-family: "Pretendard-Regular";
+	`,
+	labelLarge: css`
+		font-size: 14px;
+		line-height: 20px;
+		font-family: "Pretendard-SemiBold";
+	`,
+	labelMedium: css`
+		font-size: 12px;
+		line-height: 18px;
+		font-family: "Pretendard-Medium";
+	`,
+	labelSmall: css`
+		font-size: 10px;
+		line-height: 16px;
+		font-family: "Pretendard-Regular";
+	`,
+	caption: css`
+		font-size: 12px;
+		line-height: 18px;
+		font-family: "Pretendard-Regular";
+	`,
+};

--- a/packages/design-system/src/lib/index.web.ts
+++ b/packages/design-system/src/lib/index.web.ts
@@ -1,0 +1,3 @@
+export * from "./common/index.web";
+export * from "./constants/index.web";
+export * from "./types";

--- a/packages/design-system/tsconfig.json
+++ b/packages/design-system/tsconfig.json
@@ -7,7 +7,7 @@
 		"skipLibCheck": true,
 
 		/* Bundler mode */
-		"moduleResolution": "bundler",
+		"moduleResolution": "node",
 		"allowImportingTsExtensions": true,
 		"resolveJsonModule": true,
 		"isolatedModules": true,
@@ -18,7 +18,9 @@
 		"strict": true,
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
-		"noFallthroughCasesInSwitch": true
+		"noFallthroughCasesInSwitch": true,
+		"types": ["@emotion/react/types/css-prop"],
+		"jsxImportSource": "@emotion/react"
 	},
 	"include": ["src/lib"],
 	"references": [{ "path": "./tsconfig.node.json" }]

--- a/packages/design-system/vite.config.ts
+++ b/packages/design-system/vite.config.ts
@@ -3,15 +3,19 @@ import * as path from "path";
 import { defineConfig } from "vite";
 import dts from "vite-plugin-dts";
 
-import { name } from "./package.json";
-
 export default defineConfig({
 	build: {
 		lib: {
-			entry: path.resolve(__dirname, "src/lib/index.ts"),
-			name: "index",
-			formats: ["es", "umd"],
-			fileName: (format) => `${name}.${format}.js`,
+			entry: [
+				path.resolve(__dirname, "src/lib/index.ts"),
+				path.resolve(__dirname, "src/lib/index.web.ts"),
+			],
+			formats: ["es", "cjs"],
+			fileName: (format, entryName) => {
+				if (entryName.includes("web"))
+					return `web/design-system.web.${format}.js`;
+				return `design-system.${format}.js`;
+			},
 		},
 		rollupOptions: {
 			external: ["react", "react-native", "@emotion/native"],
@@ -25,5 +29,11 @@ export default defineConfig({
 			esmExternals: ["react"],
 		},
 	},
-	plugins: [dts({ insertTypesEntry: true, exclude: "**/*.stories.tsx" })],
+	plugins: [
+		dts({
+			outDir: "dist/types",
+			insertTypesEntry: true,
+			exclude: "**/*.stories.tsx",
+		}),
+	],
 });


### PR DESCRIPTION
# Key Changes

- dist 폴더구조를 간소화했습니다.
- web 컴포넌트를 사용할 수 있도록 환경설정을 진행했습니다.

# Details

- .d.ts의 type파일을 dist/types 폴더로 묶었습니다.
- @uoslife 위치에 있던 output 파일의 위치를 dist폴더에 위치하도록 변경했습니다.
- /web 경로에 web 컴포넌트가 번들링된 파일이 위치하도록 설정했습니다.
- 다수의 output 모듈을 cjs로 변경했습니다.
    Reference: https://vitejs.dev/guide/build.html#library-mode
- package.json의 export에 /web경로를 추가했습니다.
- web용 Txt 컴포넌트를 작성했습니다.

# Closes Issue

close #56 
