### PR TITLE
[webview] package.json의 export에 types 경로 추가

### DIFF
--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@uoslife/design-system",
 	"private": false,
-	"version": "1.2.2",
+	"version": "1.2.3",
 	"type": "module",
 	"packageManager": "pnpm@8.4.0",
 	"files": [

--- a/packages/webview/package.json
+++ b/packages/webview/package.json
@@ -10,7 +10,8 @@
 	"exports": {
 		".": {
 			"import": "./dist/@uoslife/webview.es.js",
-			"require": "./dist/@uoslife/webview.umd.js"
+			"require": "./dist/@uoslife/webview.umd.js",
+			"types": "./dist/index.d.ts"
 		}
 	},
 	"files": [

--- a/packages/webview/package.json
+++ b/packages/webview/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@uoslife/webview",
 	"private": false,
-	"version": "0.0.5",
+	"version": "0.0.6",
 	"type": "module",
 	"packageManager": "pnpm@8.4.0",
 	"main": "dist/@uoslife/webview.es.js",


### PR DESCRIPTION
# Key Changes

- fix: 타입 참조 에러를 package.json의 export에 "types": "./dist/index.d.ts" 문구를 추가하여 해결합니다.

# Closes Issue

close #62 
